### PR TITLE
Remove apple-developer-domain-association.txt setting

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5,4 +5,3 @@ en:
     apple_team_id: '(Sign in with Apple) Apple Team ID (10 characters)'
     apple_key_id: '(Sign in with Apple) Apple Key ID (10 characters)'
     apple_pem: '(Sign in with Apple) Apple Pem File Content. Include the BEGIN and END lines'
-    apple_verification_txt: "(Sign in with Apple) Paste the content of the web domain verification file here. It will be served at /.well-known/apple-developer-domain-association.txt"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,6 +6,3 @@ plugins:
   apple_pem:
     default: ''
     textarea: true
-  apple_verification_txt:
-    default: ''
-    textarea: true

--- a/plugin.rb
+++ b/plugin.rb
@@ -14,21 +14,6 @@ enabled_site_setting :sign_in_with_apple_enabled
 
 register_asset "stylesheets/apple-auth.scss"
 
-after_initialize do
-  class ::AppleVerificationController < ::ApplicationController
-    skip_before_action :check_xhr, :redirect_to_login_if_required
-
-    def index
-      raise Discourse::NotFound unless SiteSetting.apple_verification_txt.present?
-      render plain: SiteSetting.apple_verification_txt
-    end
-  end
-
-  Discourse::Application.routes.append do
-    get '/.well-known/apple-developer-domain-association.txt' => "apple_verification#index"
-  end
-end
-
 class AppleAuthenticator < ::Auth::ManagedAuthenticator
   def name
     'apple'


### PR DESCRIPTION
Verifying domains like this doesn't seem to be required by Apple any more