### PR TITLE
Fix Repo URL

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -4,7 +4,7 @@
 # about: Enable login via "Sign-in with Apple"
 # version: 1.0
 # authors: Robert Barrow, David Taylor
-# url: https://github.com/discourse/discourse-auth-apple
+# url: https://github.com/discourse/discourse-apple-auth
 
 require_relative "lib/omniauth_apple"
 


### PR DESCRIPTION
Clicking installed plugin list currently gives error 404 due to pointing at the wrong GitHub URL. 