### PR TITLE
DEV: Explicitly define primary_email_verified? method for Apple authenticator

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -43,8 +43,8 @@ class AppleAuthenticator < ::Auth::ManagedAuthenticator
           }
   end
 
-  # apple requires email verification to create your account so the email we
-  # get from them has to be verified
+  # apple requires email verification to create an account so we can assume
+  # email is verified
   def primary_email_verified?(auth_token)
     true
   end

--- a/plugin.rb
+++ b/plugin.rb
@@ -42,6 +42,12 @@ class AppleAuthenticator < ::Auth::ManagedAuthenticator
             strategy.options[:jwk_fetcher] = ->(options) { fetch_jwks(options) }
           }
   end
+
+  # apple requires email verification to create your account so the email we
+  # get from them has to be verified
+  def primary_email_verified?(auth_token)
+    true
+  end
 end
 
 auth_provider icon: 'fab-apple',


### PR DESCRIPTION
Related core PR: https://github.com/discourse/discourse/pull/19127.

Internal topic: t/82084.